### PR TITLE
Align platformVersion with pluginSinceBuild

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ pluginUntilBuild = 222.*
 
 #IntelliJ
 platformType = IU
-platformVersion = 2022.2.3
+platformVersion = 2021.3
 #platformPlugins = com.intellij.java, org.jetbrains.kotlin, PythonCore:222.4345.14, Pythonid:222.4345.6
 platformPlugins =
 


### PR DESCRIPTION
Building the project gives a bunch of dependency errors, with this error message hidden in the logs:
```
[gradle-intellij-plugin :StickyScroll:verifyPluginConfiguration] The following plugin configuration issues were found:
- The 'since-build' property is lower than the target IntelliJ Platform major version: 213.5744.223 < 222.
- The Java configuration specifies sourceCompatibility=11 but IntelliJ Platform 2022.2.3 requires sourceCompatibility=17.
See: https://jb.gg/intellij-platform-versions
```
To fix this I set `platformVersion` to the value that corresponds to `pluginSinceBuild`.

Possibly related to #15?